### PR TITLE
fix: move globby to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
+    "globby": "^8",
     "tslib": "^1"
   },
   "devDependencies": {
@@ -21,7 +22,6 @@
     "@types/mocha": "^5",
     "@types/node": "^10",
     "chai": "^4",
-    "globby": "^8",
     "mocha": "^5",
     "nyc": "^13",
     "ts-node": "^7",


### PR DESCRIPTION
When building this project using a CI tool, the package published would not run without `globby` being listed as a runtime dependency.